### PR TITLE
fix upgrade to glance 3.0

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -12,7 +12,7 @@ repository = { type = "github", user = "bcpeinhardt", repo = "glance_printer" }
 
 [dependencies]
 gleam_stdlib = "~> 0.34 or ~> 1.0"
-glance = "~> 2.0.0"
+glance = ">= 3.0.0 and < 4.0.0"
 glam = "~> 1.0 or ~> 2.0"
 
 [dev-dependencies]

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,17 +3,17 @@
 
 packages = [
   { name = "glam", version = "2.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glam", source = "hex", outer_checksum = "66EC3BCD632E51EED029678F8DF419659C1E57B1A93D874C5131FE220DFAD2B2" },
-  { name = "glance", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "784CE3B5658CF589B2E811031992FDADDFA9C7FD2A51F1140EE019F121D6D0EB" },
+  { name = "glance", version = "3.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "F3458292AFB4136CEE23142A8727C1270494E7A96978B9B9F9D2C1618583EF3D" },
   { name = "gleam_erlang", version = "0.33.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "A1D26B80F01901B59AABEE3475DD4C18D27D58FA5C897D922FCB9B099749C064" },
   { name = "gleam_stdlib", version = "0.53.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "53F3E1E56F692C20FA3E0A23650AC46592464E40D8EF3EC7F364FB328E73CDF5" },
-  { name = "glexer", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glexer", source = "hex", outer_checksum = "F74FB4F78C3C1E158DF15A7226F33A662672F58EEF1DFE6593B7FCDA38B0A0EB" },
+  { name = "glexer", version = "2.2.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glexer", source = "hex", outer_checksum = "5C235CBDF4DA5203AD5EAB1D6D8B456ED8162C5424FE2309CFFB7EF438B7C269" },
   { name = "simplifile", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "88D931B120D27A4C91EF5D6CE18E9C8FFD635D0953DA29EEDCCE93432975D2EC" },
   { name = "testbldr", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib", "simplifile"], otp_app = "testbldr", source = "hex", outer_checksum = "19C609B9CBDF3A62EABAA5E732C59918E27E993404DFAA2E3F1C5E8317A779A3" },
 ]
 
 [requirements]
 glam = { version = "~> 1.0 or ~> 2.0" }
-glance = { version = "~> 2.0.0" }
+glance = { version = ">= 3.0.0 and < 4.0.0" }
 gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
 simplifile = { version = "~> 1.1.1" }
 testbldr = { version = "~> 1.0.0" }

--- a/src/glance_printer.gleam
+++ b/src/glance_printer.gleam
@@ -190,8 +190,14 @@ fn pretty_pattern(pattern: Pattern) -> Document {
     }
 
     // Pattern for pulling off the front end of a string
-    PatternConcatenate(left, right) -> {
-      [doc.from_string("\"" <> left <> "\" <> "), pretty_assignment_name(right)]
+    PatternConcatenate(prefix, prefix_name, rest_name) -> {
+      [
+        doc.from_string("\"" <> prefix <> "\" <> "),
+        prefix_name
+          |> option.map(pretty_assignment_name)
+          |> option.unwrap(or: doc.empty),
+        pretty_assignment_name(rest_name),
+      ]
       |> doc.concat
     }
 


### PR DESCRIPTION
This allows glance 3.0.0 to be used. glance 2.x.x can not be used once the change is made.