### PR TITLE
Upgrade to `glance` 5.0.0

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -12,7 +12,8 @@ repository = { type = "github", user = "bcpeinhardt", repo = "glance_printer" }
 
 [dependencies]
 gleam_stdlib = "~> 0.34 or ~> 1.0"
-glance = ">= 3.0.0 and < 4.0.0"
+# glance = ">= 5.0.0 and < 6.0.0"
+glance = ">= 4.0.0 and < 5.0.0"
 glam = "~> 1.0 or ~> 2.0"
 
 [dev-dependencies]

--- a/gleam.toml
+++ b/gleam.toml
@@ -12,8 +12,7 @@ repository = { type = "github", user = "bcpeinhardt", repo = "glance_printer" }
 
 [dependencies]
 gleam_stdlib = "~> 0.34 or ~> 1.0"
-# glance = ">= 5.0.0 and < 6.0.0"
-glance = ">= 4.0.0 and < 5.0.0"
+glance = ">= 5.0.0 and < 6.0.0"
 glam = "~> 1.0 or ~> 2.0"
 
 [dev-dependencies]

--- a/gleam.toml
+++ b/gleam.toml
@@ -11,7 +11,7 @@ repository = { type = "github", user = "bcpeinhardt", repo = "glance_printer" }
 # links = [{ title = "Website", href = "https://gleam.run" }]
 
 [dependencies]
-gleam_stdlib = "~> 0.62.1 or ~> 1.0"
+gleam_stdlib = "~> 0.65.0 or ~> 1.0"
 glance = ">= 5.0.0 and < 6.0.0"
 glam = "~> 1.0 or ~> 2.0"
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -11,10 +11,10 @@ repository = { type = "github", user = "bcpeinhardt", repo = "glance_printer" }
 # links = [{ title = "Website", href = "https://gleam.run" }]
 
 [dependencies]
-gleam_stdlib = "~> 0.34 or ~> 1.0"
+gleam_stdlib = "~> 0.62.1 or ~> 1.0"
 glance = ">= 5.0.0 and < 6.0.0"
 glam = "~> 1.0 or ~> 2.0"
 
 [dev-dependencies]
-simplifile = "~> 1.1.1"
-testbldr = "~> 1.0.0"
+simplifile = "~> 2.3.0"
+testbldr = { git = "git@github.com:bchase/testbldr.git", ref = "upgrade-deps" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,7 +3,7 @@
 
 packages = [
   { name = "glam", version = "2.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glam", source = "hex", outer_checksum = "66EC3BCD632E51EED029678F8DF419659C1E57B1A93D874C5131FE220DFAD2B2" },
-  { name = "glance", version = "3.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "F3458292AFB4136CEE23142A8727C1270494E7A96978B9B9F9D2C1618583EF3D" },
+  { name = "glance", version = "4.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "3A58E2D9608E87A15536102C0EE5DFDEDA9D29BC8340249040E4B104436DE98A" },
   { name = "gleam_erlang", version = "0.33.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "A1D26B80F01901B59AABEE3475DD4C18D27D58FA5C897D922FCB9B099749C064" },
   { name = "gleam_stdlib", version = "0.53.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "53F3E1E56F692C20FA3E0A23650AC46592464E40D8EF3EC7F364FB328E73CDF5" },
   { name = "glexer", version = "2.2.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glexer", source = "hex", outer_checksum = "5C235CBDF4DA5203AD5EAB1D6D8B456ED8162C5424FE2309CFFB7EF438B7C269" },
@@ -13,7 +13,7 @@ packages = [
 
 [requirements]
 glam = { version = "~> 1.0 or ~> 2.0" }
-glance = { version = ">= 3.0.0 and < 4.0.0" }
+glance = { version = ">= 4.0.0 and < 5.0.0" }
 gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
 simplifile = { version = "~> 1.1.1" }
 testbldr = { version = "~> 1.0.0" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,7 +3,7 @@
 
 packages = [
   { name = "glam", version = "2.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glam", source = "hex", outer_checksum = "66EC3BCD632E51EED029678F8DF419659C1E57B1A93D874C5131FE220DFAD2B2" },
-  { name = "glance", version = "4.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "3A58E2D9608E87A15536102C0EE5DFDEDA9D29BC8340249040E4B104436DE98A" },
+  { name = "glance", version = "5.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "FAA3DAC74AF71D47C67D88EB32CE629075169F878D148BB1FF225439BE30070A" },
   { name = "gleam_erlang", version = "0.33.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "A1D26B80F01901B59AABEE3475DD4C18D27D58FA5C897D922FCB9B099749C064" },
   { name = "gleam_stdlib", version = "0.53.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "53F3E1E56F692C20FA3E0A23650AC46592464E40D8EF3EC7F364FB328E73CDF5" },
   { name = "glexer", version = "2.2.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glexer", source = "hex", outer_checksum = "5C235CBDF4DA5203AD5EAB1D6D8B456ED8162C5424FE2309CFFB7EF438B7C269" },
@@ -13,7 +13,7 @@ packages = [
 
 [requirements]
 glam = { version = "~> 1.0 or ~> 2.0" }
-glance = { version = ">= 4.0.0 and < 5.0.0" }
+glance = { version = ">= 5.0.0 and < 6.0.0" }
 gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
 simplifile = { version = "~> 1.1.1" }
 testbldr = { version = "~> 1.0.0" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -6,16 +6,16 @@ packages = [
   { name = "glam", version = "2.0.3", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glam", source = "hex", outer_checksum = "237C2CE218A2A0A5D46D625F8EF5B78F964BC91018B78D692B17E1AB84295229" },
   { name = "glance", version = "5.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "7F216D97935465FF4AC46699CD1C3E0FB19CB678B002E4ACAFCE256E96312F14" },
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
-  { name = "gleam_stdlib", version = "0.62.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "0080706D3A5A9A36C40C68481D1D231D243AF602E6D2A2BE67BA8F8F4DFF45EC" },
+  { name = "gleam_stdlib", version = "0.65.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "7C69C71D8C493AE11A5184828A77110EB05A7786EBF8B25B36A72F879C3EE107" },
   { name = "glexer", version = "2.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "splitter"], otp_app = "glexer", source = "hex", outer_checksum = "40A1FB0919FA080AD6C5809B4C7DBA545841CAAC8168FACDFA0B0667C22475CC" },
   { name = "simplifile", version = "2.3.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "0A868DAC6063D9E983477981839810DC2E553285AB4588B87E3E9C96A7FB4CB4" },
   { name = "splitter", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "05564A381580395DCDEFF4F88A64B021E8DAFA6540AE99B4623962F52976AA9D" },
-  { name = "testbldr", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib", "simplifile"], source = "git", repo = "git@github.com:bchase/testbldr.git", commit = "9b9fe9e0a42b84b51e065086244435776ffeacd6" },
+  { name = "testbldr", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib", "simplifile"], source = "git", repo = "git@github.com:bchase/testbldr.git", commit = "49f3555c031528c9aff15c9f17e2e8196574df00" },
 ]
 
 [requirements]
 glam = { version = "~> 1.0 or ~> 2.0" }
 glance = { version = ">= 5.0.0 and < 6.0.0" }
-gleam_stdlib = { version = "~> 0.62.1 or ~> 1.0" }
+gleam_stdlib = { version = "~> 0.65.0 or ~> 1.0" }
 simplifile = { version = "~> 2.3.0" }
 testbldr = { git = "git@github.com:bchase/testbldr.git", ref = "upgrade-deps" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,10 +2,10 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "glam", version = "2.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glam", source = "hex", outer_checksum = "66EC3BCD632E51EED029678F8DF419659C1E57B1A93D874C5131FE220DFAD2B2" },
+  { name = "glam", version = "2.0.3", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glam", source = "hex", outer_checksum = "237C2CE218A2A0A5D46D625F8EF5B78F964BC91018B78D692B17E1AB84295229" },
   { name = "glance", version = "5.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "FAA3DAC74AF71D47C67D88EB32CE629075169F878D148BB1FF225439BE30070A" },
-  { name = "gleam_erlang", version = "0.33.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "A1D26B80F01901B59AABEE3475DD4C18D27D58FA5C897D922FCB9B099749C064" },
-  { name = "gleam_stdlib", version = "0.53.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "53F3E1E56F692C20FA3E0A23650AC46592464E40D8EF3EC7F364FB328E73CDF5" },
+  { name = "gleam_erlang", version = "0.34.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "0C38F2A128BAA0CEF17C3000BD2097EB80634E239CE31A86400C4416A5D0FDCC" },
+  { name = "gleam_stdlib", version = "0.62.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "0080706D3A5A9A36C40C68481D1D231D243AF602E6D2A2BE67BA8F8F4DFF45EC" },
   { name = "glexer", version = "2.2.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glexer", source = "hex", outer_checksum = "5C235CBDF4DA5203AD5EAB1D6D8B456ED8162C5424FE2309CFFB7EF438B7C269" },
   { name = "simplifile", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "88D931B120D27A4C91EF5D6CE18E9C8FFD635D0953DA29EEDCCE93432975D2EC" },
   { name = "testbldr", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib", "simplifile"], otp_app = "testbldr", source = "hex", outer_checksum = "19C609B9CBDF3A62EABAA5E732C59918E27E993404DFAA2E3F1C5E8317A779A3" },

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,18 +2,20 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
   { name = "glam", version = "2.0.3", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glam", source = "hex", outer_checksum = "237C2CE218A2A0A5D46D625F8EF5B78F964BC91018B78D692B17E1AB84295229" },
-  { name = "glance", version = "5.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "FAA3DAC74AF71D47C67D88EB32CE629075169F878D148BB1FF225439BE30070A" },
-  { name = "gleam_erlang", version = "0.34.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "0C38F2A128BAA0CEF17C3000BD2097EB80634E239CE31A86400C4416A5D0FDCC" },
+  { name = "glance", version = "5.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "7F216D97935465FF4AC46699CD1C3E0FB19CB678B002E4ACAFCE256E96312F14" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
   { name = "gleam_stdlib", version = "0.62.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "0080706D3A5A9A36C40C68481D1D231D243AF602E6D2A2BE67BA8F8F4DFF45EC" },
-  { name = "glexer", version = "2.2.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glexer", source = "hex", outer_checksum = "5C235CBDF4DA5203AD5EAB1D6D8B456ED8162C5424FE2309CFFB7EF438B7C269" },
-  { name = "simplifile", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "88D931B120D27A4C91EF5D6CE18E9C8FFD635D0953DA29EEDCCE93432975D2EC" },
-  { name = "testbldr", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib", "simplifile"], otp_app = "testbldr", source = "hex", outer_checksum = "19C609B9CBDF3A62EABAA5E732C59918E27E993404DFAA2E3F1C5E8317A779A3" },
+  { name = "glexer", version = "2.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "splitter"], otp_app = "glexer", source = "hex", outer_checksum = "40A1FB0919FA080AD6C5809B4C7DBA545841CAAC8168FACDFA0B0667C22475CC" },
+  { name = "simplifile", version = "2.3.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "0A868DAC6063D9E983477981839810DC2E553285AB4588B87E3E9C96A7FB4CB4" },
+  { name = "splitter", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "05564A381580395DCDEFF4F88A64B021E8DAFA6540AE99B4623962F52976AA9D" },
+  { name = "testbldr", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib", "simplifile"], source = "git", repo = "git@github.com:bchase/testbldr.git", commit = "9b9fe9e0a42b84b51e065086244435776ffeacd6" },
 ]
 
 [requirements]
 glam = { version = "~> 1.0 or ~> 2.0" }
 glance = { version = ">= 5.0.0 and < 6.0.0" }
-gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
-simplifile = { version = "~> 1.1.1" }
-testbldr = { version = "~> 1.0.0" }
+gleam_stdlib = { version = "~> 0.62.1 or ~> 1.0" }
+simplifile = { version = "~> 2.3.0" }
+testbldr = { git = "git@github.com:bchase/testbldr.git", ref = "upgrade-deps" }

--- a/src/glance_printer.gleam
+++ b/src/glance_printer.gleam
@@ -13,9 +13,9 @@ import glance.{
   Int, IntOption, LabelledField, LabelledVariantField, Let, LetAssert, LittleOption,
   LtEqFloat, LtEqInt, LtFloat, LtInt, Module, MultFloat, MultInt, Named,
   NamedType, NativeOption, NegateBool, NegateInt, NotEq, Or, Panic,
-  PatternAssignment, PatternBitString, PatternConcatenate, PatternConstructor,
+  PatternAssignment, PatternBitString, PatternConcatenate,
   PatternDiscard, PatternFloat, PatternInt, PatternList, PatternString,
-  PatternTuple, PatternVariable, Pipe, Private, Public, RecordUpdate,
+  PatternTuple, PatternVariable, PatternVariant, Pipe, Private, Public, RecordUpdate,
   RecordUpdateField, RemainderInt, ShorthandField, SignedOption, SizeOption,
   SizeValueOption, String, SubFloat, SubInt, Todo, Tuple, TupleIndex, TupleType,
   TypeAlias, UnitOption, UnlabelledField, UnlabelledVariantField, UnsignedOption,
@@ -210,7 +210,7 @@ fn pretty_pattern(pattern: Pattern) -> Document {
 
     PatternBitString(segments) -> pretty_bitstring(segments, pretty_pattern)
 
-    PatternConstructor(module, constructor, arguments, with_spread) -> {
+    PatternVariant(module:, constructor:, arguments:, with_spread:) -> {
       let module =
         module
         |> option.map(doc.from_string)

--- a/src/glance_printer.gleam
+++ b/src/glance_printer.gleam
@@ -4,23 +4,24 @@ import glance.{
   type BitStringSegmentOption, type Constant, type CustomType, type Definition,
   type Expression, type Field, type FnParameter, type Function,
   type FunctionParameter, type Import, type Module, type Pattern, type Publicity,
-  type Statement, type Type, type TypeAlias, type UsePattern, type Variant, AddFloat, AddInt, And,
-  Assert, Assignment, Attribute, BigOption, BinaryOperator, BitString,
-  BitsOption, Block, BytesOption, Call, Case, Clause, Concatenate, Constant,
-  CustomType, Definition, Discarded, DivFloat, DivInt, Echo, Eq, Expression,
-  FieldAccess, Float, FloatOption, Fn, FnCapture, FnParameter, Function,
-  FunctionParameter, FunctionType, GtEqFloat, GtEqInt, GtFloat, GtInt, Import,
-  Int, IntOption, LabelledField, LabelledVariantField, Let, LetAssert, LittleOption,
-  LtEqFloat, LtEqInt, LtFloat, LtInt, Module, MultFloat, MultInt, Named,
-  NamedType, NativeOption, NegateBool, NegateInt, NotEq, Or, Panic,
-  PatternAssignment, PatternBitString, PatternConcatenate,
+  type Statement, type Type, type TypeAlias, type UsePattern, type Variant,
+  AddFloat, AddInt, And, Assert, Assignment, Attribute, BigOption,
+  BinaryOperator, BitString, BitsOption, Block, BytesOption, Call, Case, Clause,
+  Concatenate, Constant, CustomType, Definition, Discarded, DivFloat, DivInt,
+  Echo, Eq, Expression, FieldAccess, Float, FloatOption, Fn, FnCapture,
+  FnParameter, Function, FunctionParameter, FunctionType, GtEqFloat, GtEqInt,
+  GtFloat, GtInt, Import, Int, IntOption, LabelledField, LabelledVariantField,
+  Let, LetAssert, LittleOption, LtEqFloat, LtEqInt, LtFloat, LtInt, Module,
+  MultFloat, MultInt, Named, NamedType, NativeOption, NegateBool, NegateInt,
+  NotEq, Or, Panic, PatternAssignment, PatternBitString, PatternConcatenate,
   PatternDiscard, PatternFloat, PatternInt, PatternList, PatternString,
-  PatternTuple, PatternVariable, PatternVariant, Pipe, Private, Public, RecordUpdate,
-  RecordUpdateField, RemainderInt, ShorthandField, SignedOption, SizeOption,
-  SizeValueOption, String, SubFloat, SubInt, Todo, Tuple, TupleIndex, TupleType,
-  TypeAlias, UnitOption, UnlabelledField, UnlabelledVariantField, UnsignedOption,
-  Use, UsePattern, Utf16CodepointOption, Utf16Option, Utf32CodepointOption, Utf32Option,
-  Utf8CodepointOption, Utf8Option, Variable, VariableType, Variant,
+  PatternTuple, PatternVariable, PatternVariant, Pipe, Private, Public,
+  RecordUpdate, RecordUpdateField, RemainderInt, ShorthandField, SignedOption,
+  SizeOption, SizeValueOption, String, SubFloat, SubInt, Todo, Tuple, TupleIndex,
+  TupleType, TypeAlias, UnitOption, UnlabelledField, UnlabelledVariantField,
+  UnsignedOption, Use, UsePattern, Utf16CodepointOption, Utf16Option,
+  Utf32CodepointOption, Utf32Option, Utf8CodepointOption, Utf8Option, Variable,
+  VariableType, Variant,
 }
 import glance_printer/internal/doc_extras.{
   comma_separated_in_parentheses, nbsp, nest, trailing_comma,
@@ -167,10 +168,7 @@ fn pretty_statement(statement: Statement) -> Document {
           |> doc.concat
 
         None ->
-          [
-            doc.from_string("assert "),
-            pretty_expression(expression),
-          ]
+          [doc.from_string("assert "), pretty_expression(expression)]
           |> doc.concat
       }
     }
@@ -181,10 +179,7 @@ fn pretty_statement(statement: Statement) -> Document {
 fn pretty_use_pattern(use_pattern: UsePattern) -> Document {
   let UsePattern(pattern:, annotation:) = use_pattern
 
-  [
-    pretty_pattern(pattern),
-    pretty_type_annotation(annotation),
-  ]
+  [pretty_pattern(pattern), pretty_type_annotation(annotation)]
   |> doc.concat
 }
 
@@ -192,8 +187,9 @@ fn pretty_use_pattern(use_pattern: UsePattern) -> Document {
 fn pretty_pattern(pattern: Pattern) -> Document {
   case pattern {
     // Basic patterns
-    PatternInt(value:, location: _) | PatternFloat(value:, location: _) | PatternVariable(name: value, location: _) ->
-      doc.from_string(value)
+    PatternInt(value:, location: _)
+    | PatternFloat(value:, location: _)
+    | PatternVariable(name: value, location: _) -> doc.from_string(value)
 
     PatternString(value:, location: _) -> doc.from_string("\"" <> value <> "\"")
 
@@ -231,7 +227,8 @@ fn pretty_pattern(pattern: Pattern) -> Document {
       |> doc.concat
     }
 
-    PatternBitString(segments:, location: _) -> pretty_bitstring(segments, pretty_pattern)
+    PatternBitString(segments:, location: _) ->
+      pretty_bitstring(segments, pretty_pattern)
 
     PatternVariant(module:, constructor:, arguments:, with_spread:, location: _) -> {
       let module =
@@ -325,7 +322,9 @@ fn pretty_list(
 fn pretty_expression(expression: Expression) -> Document {
   case expression {
     // Int, Float and Variable simply print as their string value
-    Int(value:, location: _) | Float(value:, location: _) | Variable(name: value, location: _) -> doc.from_string(value)
+    Int(value:, location: _)
+    | Float(value:, location: _)
+    | Variable(name: value, location: _) -> doc.from_string(value)
 
     // A string literal needs to bee wrapped in quotes
     String(value:, location: _) -> doc.from_string("\"" <> value <> "\"")
@@ -375,7 +374,8 @@ fn pretty_expression(expression: Expression) -> Document {
       )
 
     // Pretty print a function
-    Fn(arguments:, return_annotation: return, body:, location: _) -> pretty_fn(arguments, return, body)
+    Fn(arguments:, return_annotation: return, body:, location: _) ->
+      pretty_fn(arguments, return, body)
 
     // Pretty print a record update expression
     RecordUpdate(module:, constructor:, record:, fields:, location: _) -> {
@@ -425,7 +425,13 @@ fn pretty_expression(expression: Expression) -> Document {
       |> doc.concat
     }
 
-    FnCapture(label:, function:, arguments_before:, arguments_after:, location: _) -> {
+    FnCapture(
+      label:,
+      function:,
+      arguments_before:,
+      arguments_after:,
+      location: _,
+    ) -> {
       let arguments_before =
         list.map(arguments_before, pretty_field(_, pretty_expression))
       let arguments_after =
@@ -443,7 +449,8 @@ fn pretty_expression(expression: Expression) -> Document {
       [pretty_expression(function), in_parens]
       |> doc.concat
     }
-    BitString(segments:, location: _) -> pretty_bitstring(segments, pretty_expression)
+    BitString(segments:, location: _) ->
+      pretty_bitstring(segments, pretty_expression)
     Case(subjects:, clauses:, location: _) -> {
       let subjects =
         subjects
@@ -495,14 +502,10 @@ fn pretty_expression(expression: Expression) -> Document {
     }
     Echo(expression:, location: _) -> {
       case expression {
-        None ->
-          doc.from_string("echo")
+        None -> doc.from_string("echo")
 
         Some(expression) ->
-          [
-            doc.from_string("echo "),
-            pretty_expression(expression),
-          ]
+          [doc.from_string("echo "), pretty_expression(expression)]
           |> doc.concat
       }
     }
@@ -701,9 +704,9 @@ fn pretty_type(type_: Type) -> Document {
 }
 
 fn pretty_custom_type(type_: Definition(CustomType)) -> Document {
-  use CustomType(name:, publicity:, opaque_:, parameters:, variants:, location: _) <- pretty_definition(
-    type_,
-  )
+  use
+    CustomType(name:, publicity:, opaque_:, parameters:, variants:, location: _)
+  <- pretty_definition(type_)
 
   // Opaque or not
   let opaque_ = case opaque_ {
@@ -767,16 +770,14 @@ fn pretty_variant(variant: Variant) -> Document {
     |> comma_separated_in_parentheses
     |> doc.prepend(doc.from_string(name))
 
-  let attrs =
-    case attributes |> list.map(pretty_attribute) {
-      [] ->
-        []
+  let attrs = case attributes |> list.map(pretty_attribute) {
+    [] -> []
 
-      attrs ->
-        attrs
-        |> list.intersperse(doc.break("", ""))
-        |> list.append([doc.break("", "")])
-    }
+    attrs ->
+      attrs
+      |> list.intersperse(doc.break("", ""))
+      |> list.append([doc.break("", "")])
+  }
 
   list.append(attrs, [var])
   |> doc.concat
@@ -799,9 +800,15 @@ fn pretty_field(field: Field(a), a_to_doc: fn(a) -> Document) -> Document {
 
 // Pretty print an import statement
 fn pretty_import(import_: Definition(Import)) -> Document {
-  use Import(module:, alias:, unqualified_types:, unqualified_values:, location: _) <- pretty_definition(
-    import_,
-  )
+  use
+    Import(
+      module:,
+      alias:,
+      unqualified_types:,
+      unqualified_values:,
+      location: _,
+    )
+  <- pretty_definition(import_)
 
   let unqualified_values =
     unqualified_values

--- a/src/glance_printer.gleam
+++ b/src/glance_printer.gleam
@@ -156,13 +156,14 @@ fn pretty_statement(statement: Statement) -> Document {
       |> doc.concat
     }
     Assert(expression:, message:) ->
-      todo
+      doc.zero_width_string("") // TODO
   }
 }
 
 /// Pretty print a "use pattern" (anything that could go in a `use` pattern match branch)
 fn pretty_use_pattern(use_pattern: UsePattern) -> Document {
-  todo
+  let UsePattern(pattern:, annotation: _) = use_pattern // TODO `annotation`
+  pretty_pattern(pattern)
 }
 
 /// Pretty print a "pattern" (anything that could go in a pattern match branch)

--- a/src/glance_printer.gleam
+++ b/src/glance_printer.gleam
@@ -183,7 +183,7 @@ fn pretty_use_pattern(use_pattern: UsePattern) -> Document {
 
   [
     pretty_pattern(pattern),
-    pretty_type_annotation(annotation), // TODO test?
+    pretty_type_annotation(annotation),
   ]
   |> doc.concat
 }
@@ -493,12 +493,14 @@ fn pretty_expression(expression: Expression) -> Document {
       ]
       |> doc.concat
     }
-    Echo(expression:, location: _) -> { // TODO test
+    Echo(expression:, location: _) -> {
       case expression {
-        None -> doc.from_string("echo")
+        None ->
+          doc.from_string("echo")
+
         Some(expression) ->
           [
-            doc.from_string("echo"),
+            doc.from_string("echo "),
             pretty_expression(expression),
           ]
           |> doc.concat

--- a/src/glance_printer.gleam
+++ b/src/glance_printer.gleam
@@ -155,15 +155,37 @@ fn pretty_statement(statement: Statement) -> Document {
       ]
       |> doc.concat
     }
-    Assert(expression:, message:, location: _) ->
-      doc.zero_width_string("") // TODO
+    Assert(expression:, message:, location: _) -> {
+      case message {
+        Some(message) ->
+          [
+            doc.from_string("assert "),
+            pretty_expression(expression),
+            doc.from_string(" as "),
+            pretty_expression(message),
+          ]
+          |> doc.concat
+
+        None ->
+          [
+            doc.from_string("assert "),
+            pretty_expression(expression),
+          ]
+          |> doc.concat
+      }
+    }
   }
 }
 
 /// Pretty print a "use pattern" (anything that could go in a `use` pattern match branch)
 fn pretty_use_pattern(use_pattern: UsePattern) -> Document {
-  let UsePattern(pattern:, annotation: _) = use_pattern // TODO `annotation`
-  pretty_pattern(pattern)
+  let UsePattern(pattern:, annotation:) = use_pattern
+
+  [
+    pretty_pattern(pattern),
+    pretty_type_annotation(annotation), // TODO test?
+  ]
+  |> doc.concat
 }
 
 /// Pretty print a "pattern" (anything that could go in a pattern match branch)
@@ -471,9 +493,17 @@ fn pretty_expression(expression: Expression) -> Document {
       ]
       |> doc.concat
     }
-
-    Echo(expression:, location: _) ->
-      todo
+    Echo(expression:, location: _) -> { // TODO test
+      case expression {
+        None -> doc.from_string("echo")
+        Some(expression) ->
+          [
+            doc.from_string("echo"),
+            pretty_expression(expression),
+          ]
+          |> doc.concat
+      }
+    }
   }
 }
 
@@ -719,7 +749,7 @@ fn pretty_variant(variant: Variant) -> Document {
   //   UnlabelledVariantField(item: Type)
   // }
 
-  let Variant(name:, fields:, ..) = variant // TODO `attributes`
+  let Variant(name:, fields:, attributes: _) = variant // TODO `attributes`
   fields
   |> list.map(fn(field) {
     case field {

--- a/test/gleam_examples/custom_types.gleam
+++ b/test/gleam_examples/custom_types.gleam
@@ -1,5 +1,6 @@
 pub opaque type Pet(a, b) {
   Cat(name: String, color: String)
+  @deprecated("deprecated")
   Dog(barks: Bool)
 }
 

--- a/test/gleam_examples/expressions.gleam
+++ b/test/gleam_examples/expressions.gleam
@@ -1,5 +1,5 @@
-import gleam/list
 import gleam/bit_array
+import gleam/list
 
 const x = 5
 

--- a/test/gleam_examples/expressions.gleam
+++ b/test/gleam_examples/expressions.gleam
@@ -18,6 +18,8 @@ fn foo() {
   panic as "Some message"
   todo
   todo as "Some message"
+  echo "Some message"
+  "Some message" |> echo
   #(1, "text", True, x)
   #(
     1,

--- a/test/gleam_examples/expressions.gleam
+++ b/test/gleam_examples/expressions.gleam
@@ -19,6 +19,8 @@ fn foo() {
   todo
   todo as "Some message"
   echo "Some message"
+  assert True
+  assert True as "Some message"
   "Some message" |> echo
   #(1, "text", True, x)
   #(

--- a/test/gleam_examples/use_statement.gleam
+++ b/test/gleam_examples/use_statement.gleam
@@ -1,8 +1,14 @@
 import gleam/int
 import gleam/io
 import gleam/list
+import gleam/result
 
 fn use_statement() {
   use number <- list.each([1, 2, 3, 4, 5])
   Nil
+}
+
+fn use_statement_typed() {
+  use num: Int <- result.try(Ok(123))
+  Ok(num)
 }


### PR DESCRIPTION
`glance` 5.0.0 includes the following changes:

- fixes parsing of `use` statements to optionally include a type annotation
- parses `echo`
- parses `assert` (without `let`)
- parses type variant annotations (e.g. `@deprecated`)
- adds `location` fields to many of the `glance` types (note: unused by `glance_printer`)

This is my attempt at upgrading `glance_printer` to accommodate these changes. I also added to the example files to test for each of the new features above (except for `location`s).